### PR TITLE
Test playbook support

### DIFF
--- a/roles/com_redhat_tuned/test/main.yml
+++ b/roles/com_redhat_tuned/test/main.yml
@@ -10,34 +10,76 @@
     msg: "Service tuned is not enabled or running"
   when: service_status.changed
 
+# legacy tuned-adm does not have recommend command
+- name: Get recommended profile
+  command: tuned-adm recommend
+  register: recommend
+  ignore_errors: yes
+
+- name: Set legacy value
+  set_fact:
+    legacy: "{{ recommend.rc != 0 }}"
+
 - name: Get active profile
   command: tuned-adm active
   register: active
 
-# extract profile name
-- set_fact:
-    active_profile: "{{ active.stdout | regex_replace('^.*\\: (.*)$', '\\1') }}"
+- name: Extract profile name
+  set_fact:
+    active_profile: "{{ active.stdout_lines[0] | regex_replace('^.*\\: (.*)$', '\\1') }}"
 
-# if profile is undefined use api default
-- set_fact:
+- name: if profile is undefined use api default
+  set_fact:
     profile: balanced
   when: profile is undefined
 
-# compare expected and active profiles only if use_recommended_profile is not used
-- assert:
-    that: profile == active_profile
-    msg: "AssertionError {{ profile }} != {{ active_profile }}"
-  when: use_recommended_profile is undefined
-
-# use_recommended_profile is used, get the recommended profile and compare
+# non-legacy block
 - block:
-    - name: Get recommended profile
-      command: tuned-adm recommend
-      register: recommend
+  - name: Compare expected and active profiles only if use_recommended_profile is not used
+    assert:
+      that: profile == active_profile
+      msg: "AssertionError {{ profile }} != {{ active_profile }}"
+    when:
+      - use_recommended_profile is undefined or not use_recommended_profile
 
-    - assert:
-        that: recommend.stdout == active_profile
-        msg: "AssertionError {{ recommend.stdout }} != {{ active_profile }}"
-  when:
+  - name: When use_recommended_profile is used, get the recommended profile and compare
+    assert:
+      that: recommend.stdout == active_profile
+      msg: "AssertionError {{ recommend.stdout }} != {{ active_profile }}"
+    when:
     - use_recommended_profile is defined
     - use_recommended_profile
+  when: not legacy
+
+# legacy block
+- block:
+  # make a copy
+  - set_fact:
+      profile_1: "{{ profile }}"
+
+  # remap new to legacy profiles
+  - name: balanced -> default
+    set_fact:
+      profile_1: default
+    when: profile == "balanced"
+
+  - name: powersave -> server-powersave
+    set_fact:
+      profile_1: server-powersave
+    when: profile == "powersave"
+
+  - name: Compare expected and active profiles only if use_recommended_profile is not used
+    assert:
+      that: profile_1 == active_profile
+      msg: "AssertionError {{ profile_1 }} != {{ active_profile }}"
+    when:
+      - use_recommended_profile is undefined or not use_recommended_profile
+
+  - name: When use_recommended_profile is used, get the recommended profile and compare
+    assert:
+      that: "'default' == active_profile"
+      msg: "AssertionError default != {{ active_profile }}"
+    when:
+    - use_recommended_profile is defined
+    - use_recommended_profile
+  when: legacy

--- a/roles/com_redhat_tuned/test/main.yml
+++ b/roles/com_redhat_tuned/test/main.yml
@@ -1,0 +1,39 @@
+- name: Check if tuned enabled and running
+  service:
+    name: tuned
+    enabled: yes
+    state: started
+  check_mode: yes
+  register: service_status
+
+- fail:
+    msg: "Service tuned is not enabled or running"
+  when: service_status.changed
+
+- name: Get active profile
+  command: tuned-adm active
+  register: active
+
+# extract profile name
+- set_fact:
+    active_profile: "{{ active.stdout | regex_replace('^.*\\: (.*)$', '\\1') }}"
+
+# compare expected and active profiles only if use_recommended_profile is not used
+- assert:
+    that: profile == active_profile
+    msg: "AssertionError {{ profile }} != {{ active_profile }}"
+  when:
+    - use_recommended_profile is undefined
+
+# use_recommended_profile is used, get the recommended profile and compare
+- block:
+    - name: Get recommended profile
+      command: tuned-adm recommend
+      register: recommend
+
+    - assert:
+        that: recommend.stdout == active_profile
+        msg: "AssertionError {{ recommend.stdout }} != {{ active_profile }}"
+  when:
+    - use_recommended_profile is defined
+    - use_recommended_profile

--- a/roles/com_redhat_tuned/test/main.yml
+++ b/roles/com_redhat_tuned/test/main.yml
@@ -18,12 +18,16 @@
 - set_fact:
     active_profile: "{{ active.stdout | regex_replace('^.*\\: (.*)$', '\\1') }}"
 
+# if profile is undefined use api default
+- set_fact:
+    profile: balanced
+  when: profile is undefined
+
 # compare expected and active profiles only if use_recommended_profile is not used
 - assert:
     that: profile == active_profile
     msg: "AssertionError {{ profile }} != {{ active_profile }}"
-  when:
-    - use_recommended_profile is undefined
+  when: use_recommended_profile is undefined
 
 # use_recommended_profile is used, get the recommended profile and compare
 - block:

--- a/test/machine.py
+++ b/test/machine.py
@@ -41,11 +41,21 @@ class Machine(object):
             f.write(host)
 
     def set_config(self, interface, **config):
+        iface_dir = interface.replace('.', '_')
         play = {
-                'hosts': 'system-api-test',
-                'become': True,
-                'roles': [ dict(role=interface.replace('.', '_'), **config) ]
+            'hosts': 'system-api-test',
+            'become': True,
+            'roles': [dict(role=iface_dir, **config)]
         }
+
+        testbook_path = os.path.join(self.rolesdir, iface_dir, 'test',
+                                     'main.yml')
+        if os.path.exists(testbook_path):
+            play['post_tasks'] = [{
+                'include': testbook_path,
+                'vars': config
+            }]
+
         playbook = [ play ]
 
         playbook_file = os.path.join(self.workdir, 'test.yml')

--- a/test/machine.py
+++ b/test/machine.py
@@ -40,7 +40,7 @@ class Machine(object):
         with open(self.inventory_file, 'w') as f:
             f.write(host)
 
-    def set_config(self, interface, **config):
+    def set_config(self, interface, test_tasks_file=None, **config):
         iface_dir = interface.replace('.', '_')
         play = {
             'hosts': 'system-api-test',
@@ -48,9 +48,9 @@ class Machine(object):
             'roles': [dict(role=iface_dir, **config)]
         }
 
-        testbook_path = os.path.join(self.rolesdir, iface_dir, 'test',
-                                     'main.yml')
-        if os.path.exists(testbook_path):
+        if test_tasks_file:
+            testbook_path = os.path.join(self.rolesdir, iface_dir, 'test',
+                                         test_tasks_file)
             play['post_tasks'] = [{
                 'include': testbook_path,
                 'vars': config

--- a/test/test-tuned.py
+++ b/test/test-tuned.py
@@ -10,43 +10,10 @@ class TestTuned(machine.Test):
     :avocado: enable
     """
 
-    # reverse from the one in defaults/main.yaml
-    legacy_profiles_map = { 'default': 'balanced', 'server-powersave': 'powersave'}
-
     def test(self):
-        # run the playbook once with defaults to ensure that tuned is installed
-        self.machine.set_config('com.redhat.tuned')
-
-        # check if we're running on an old version of tuned, which doesn't accept --version
-        try:
-            self.machine.execute('sudo tuned-adm --version')
-        except process.CmdError:
-            self.legacy = True
-        else:
-            self.legacy = False
-
-        # the default profile is 'balanced'
-        self.assertEqual(self.get_active_profile(), 'balanced')
-
-        for profile in ('balanced', 'powersave', 'throughput-performance', 'latency-performance'):
+        for profile in ('balanced', 'powersave', 'throughput-performance',
+                        'latency-performance'):
             self.machine.set_config('com.redhat.tuned', profile=profile)
-            self.assertEqual(profile, self.get_active_profile())
 
-        if not self.legacy:
-            recommended = self.machine.execute('sudo tuned-adm recommend').strip()
-        else:
-            # legacy tuned doesn't have the notion of a recommended profile,
-            # but should use 'default' (which maps to 'balanced')
-            recommended = 'balanced'
-
-        self.machine.set_config('com.redhat.tuned', use_recommended_profile=True)
-        self.assertEqual(recommended, self.get_active_profile())
-
-    def get_active_profile(self):
-        output = self.machine.execute('sudo tuned-adm active')
-        profile = re.match('^.*: (.*)$', output, re.MULTILINE).group(1)
-
-        if self.legacy:
-            return self.legacy_profiles_map.get(profile, profile)
-        else:
-            return profile
+        self.machine.set_config('com.redhat.tuned',
+                                use_recommended_profile=True)

--- a/test/test-tuned.py
+++ b/test/test-tuned.py
@@ -1,7 +1,4 @@
-
 import machine
-import re
-from avocado.utils import process
 
 
 class TestTuned(machine.Test):

--- a/test/test-tuned.py
+++ b/test/test-tuned.py
@@ -10,7 +10,9 @@ class TestTuned(machine.Test):
     def test(self):
         for profile in ('balanced', 'powersave', 'throughput-performance',
                         'latency-performance'):
-            self.machine.set_config('com.redhat.tuned', profile=profile)
+            self.machine.set_config('com.redhat.tuned', profile=profile,
+                                    test_tasks_file='main.yml')
 
         self.machine.set_config('com.redhat.tuned',
-                                use_recommended_profile=True)
+                                use_recommended_profile=True,
+                                test_tasks_file='main.yml')

--- a/test/test-tuned.py
+++ b/test/test-tuned.py
@@ -9,7 +9,7 @@ class TestTuned(machine.Test):
 
     def test(self):
         for profile in ('balanced', 'powersave', 'throughput-performance',
-                        'latency-performance'):
+                        'latency-performance', 'virtual-guest', 'virtual-host'):
             self.machine.set_config('com.redhat.tuned', profile=profile,
                                     test_tasks_file='main.yml')
 


### PR DESCRIPTION
This pull request adds ability to write test tasks for each api role and include them as post_tasks within the test playbook. It's still possible to cover all api testing in python, but writing tests (or at least major part) in ansible seems to me easier (running in the same play vs. bunch of subprocess ssh to remote) and organized (big slice of test logic in the api directory structure).